### PR TITLE
Fix a synchronization issue when in the `#teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # 1.0.1
 - Fix a synchronization issue when doing file rotation and checking the size of the current file
+- Fix an issue with synchronization when shutting down the plugin and closing the current temp file

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -313,7 +313,9 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
     shutdown_upload_workers
     @periodic_rotation_thread.stop! if @periodic_rotation_thread
 
-    @tempfile.close
+    @file_rotation_lock.synchronize do
+      @tempfile.close unless @tempfile.nil? && @tempfile.closed?
+    end
     finished
   end
 


### PR DESCRIPTION
Multiple threads were accessing the tempfile when we were trying to
shutdown the pipeline. This issues was the cause of a non deterministic
test for testing the file rotation.

Fixes #23