### PR TITLE
Support for dynamic prefix field based s3 directory separation

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -473,8 +473,13 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   private
   def delete_on_bucket(filename)
     bucket = @s3.buckets[@bucket]
+    
+    first = Pathname.new @temporary_directory
+    second = Pathname.new filename
 
-    remote_filename = "#{@prefix}#{File.basename(filename)}"
+    remote_filename_path = second.relative_path_from first
+    
+    remote_filename = remote_filename_path.to_s
 
     @logger.debug("S3: delete file from bucket", :remote_filename => remote_filename, :bucket => @bucket)
 


### PR DESCRIPTION
One may not provide the dynamic prefixes like "logs/%{app}/%{type}/" . Fields can be extracted from the event messages.

This will create the temp file locally per prefix and apply a time_file watch on each prefix. Change also maintains a separate file lock for each prefix.

After no_event_wait time, it will reset the watch and do a local clean-up for the files under a prefix. This will happen if there has been no event for that prefix, in last no_event_wait * time_file time from the last event.