### PR TITLE
Reintroduce `tags` in the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Fixes an issue when tags were defined #39
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -110,6 +110,16 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   # Specify how many workers to use to upload the files to S3
   config :upload_workers_count, :validate => :number, :default => 1
 
+  # Define tags to be appended to the file on the S3 bucket.
+  #
+  # Example:
+  # tags => ["elasticsearch", "logstash", "kibana"]
+  #
+  # Will generate this file:
+  # "ls.s3.logstash.local.2015-01-01T00.00.tag_elasticsearch.logstash.kibana.part0.txt"
+  # 
+  config :tags, :validate => :array, :default => []
+
   # Exposed attributes for testing purpose.
   attr_accessor :tempfile
   attr_reader :page_counter

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-s3'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Logstash 2.0 has marked `tags` as an obsolete option for filtering the
events. But this plugins also uses tags for generating the filename
before sending it to s3.

Fixes #39