### PR TITLE
Write UTC timestamp to filename instead of local time

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -275,7 +275,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   public
   def get_temporary_filename(page_counter = 0)
-    current_time = Time.now
+    current_time = Time.now.utc
     filename = "ls.s3.#{Socket.gethostname}.#{current_time.strftime("%Y-%m-%dT%H.%M")}"
 
     if @tags.size > 0


### PR DESCRIPTION
Thereby, it is easier to process the data in clouds such as AWS.
