### PR TITLE
Allow setting a header row to s3 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3
+ - Adds ability to set a file header
+
 ## 2.0.2
  - Fixes an issue when tags were defined #39
 ## 2.0.0

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -119,6 +119,15 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   #
   config :tags, :validate => :array, :default => []
 
+  # If set, this will be the first row of every file pushed to S3
+  #
+  # Ensure that you are setting this to the actual number of columns in your data.  It is not dynamic
+  # and will not help you out if the underlying schema changes.  
+  #
+  # Recommend to use wtih this a filter that produces an explicit set of fields no matter the input
+  # event
+  config :header_row, :validate => :string, :default => ""
+
   # Exposed attributes for testing purpose.
   attr_accessor :tempfile
   attr_reader :page_counter
@@ -180,6 +189,11 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
       end
 
       @tempfile = File.open(filename, "a")
+      
+      #  header row processing
+      if @headerrow.eql? "" 
+        @tempfile.syswrite(@headerrow)
+      end
     end
   end
 


### PR DESCRIPTION
To support downstream consumption of files produced by logstash's s3 output, allow a hardcoded header row to be supplied in the configuration of the outputter.