### PR TITLE
Flushing data on close

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -340,6 +340,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
     @file_rotation_lock.synchronize do
       @tempfile.close unless @tempfile.nil? && @tempfile.closed?
+      move_file_to_bucket(@tempfile.path) unless @tempfile.nil?
     end
   end
 

--- a/spec/integration/s3_spec.rb
+++ b/spec/integration/s3_spec.rb
@@ -28,6 +28,15 @@ describe LogStash::Outputs::S3, :integration => true, :s3 => true do
     delete_matching_keys_on_bucket('my-prefix')
   end
 
+  describe '#close' do
+    it 'flushes to s3' do
+      s3 = LogStash::Outputs::S3.new(minimal_settings)
+      s3.register
+      expect(s3).to receive(:move_file_to_bucket)
+      s3.close
+    end
+  end
+
   describe "#register" do
     it "write a file on the bucket to check permissions" do
       s3 = LogStash::Outputs::S3.new(minimal_settings)


### PR DESCRIPTION
Uploading the file to S3 on close to prevent data from being lost when logstash is shutdown.

Fixes #68 
