### PR TITLE
Fix close behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 3.1.1
-  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
-
-## 3.1.0
- - breaking,config: Remove deprecated config `endpoint_region`. Please use `region` instead.
-
+## 3.1.2
+  - Fix improper shutdown of output worker threads
+  - improve exception handling
 ## 3.0.1
  - Republish all the gems under jruby.
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -370,7 +370,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   private
   def shutdown_upload_workers
     @logger.debug("S3: Gracefully shutdown the upload workers")
-    @upload_queue << LogStash::ShutdownEvent
+    @upload_queue << LogStash::SHUTDOWN
   end
 
   private
@@ -424,7 +424,12 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
         while true do
           @logger.debug("S3: upload worker is waiting for a new file to upload.", :worker_id => worker_id)
 
-          upload_worker
+          begin
+            upload_worker
+          rescue Exception => ex
+            @logger.error('upload_worker unhandled exception', :ex => ex, :backtrace => ex.backtrace)
+            raise LogStash::Error, 'S3: uploader thread exited unexpectedly'
+          end
         end
       end
     end
@@ -432,15 +437,23 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   private
   def upload_worker
-    file = @upload_queue.deq
+    file = nil
+    begin
+      file = @upload_queue.deq
 
-    case file
-      when LogStash::ShutdownEvent
+      if file.is_a? LogStash::ShutdownEvent
         @logger.debug("S3: upload worker is shutting down gracefuly")
-        @upload_queue.enq(LogStash::ShutdownEvent)
+        @upload_queue.enq(LogStash::SHUTDOWN)
       else
         @logger.debug("S3: upload working is uploading a new file", :filename => File.basename(file))
         move_file_to_bucket(file)
+      end
+    rescue Exception => ex
+      @logger.error("failed to upload, will re-enqueue #{file} for upload",
+                    :ex => ex, :backtrace => ex.backtrace)
+      unless file.nil?
+        @upload_queue.enq(file)
+      end
     end
   end
 

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-s3'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -302,6 +302,33 @@ describe LogStash::Outputs::S3 do
       end
     end
 
+    describe "closing" do
+      let(:options) do
+        {
+          "access_key_id" => 1234,
+          "secret_access_key" => "secret",
+          "bucket" => "mahbucket"
+        }
+      end
+      subject do
+        ::LogStash::Outputs::S3.new(options)
+      end
+
+      before do
+        subject.register
+      end
+
+      it "should be clean" do
+        subject.do_close
+      end
+
+      it "should remove all worker threads" do
+        subject.do_close
+        sleep 1
+        expect(subject.upload_workers.map(&:thread).any?(&:alive?)).to be false
+      end
+    end
+
     it "doesn't skip events if using the time_file option", :tag => :slow do
       Stud::Temporary.directory do |temporary_directory|
         time_file = rand(1..2)


### PR DESCRIPTION
Before workers did not cleanly shutdown resulting in a potential thread leak.

Also includes the patches in #80 , it makes more sense to merge these together as this patch includes spces.