### PR TITLE
Fix config value for KMS encryption

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -103,8 +103,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :canned_acl, :validate => ["private", "public_read", "public_read_write", "authenticated_read"],
          :default => "private"
 
-  # Specifies wether or not to use S3's AES256 server side encryption. Defaults to false.
-  config :server_side_encryption, :validate => :boolean, :default => false
+  # Specifies whether or not to use S3's AES256 server side encryption. Defaults to false.
+  config :server_side_encryption, :validate => ['AES256', 'aws:kms'], :default => nil
 
   # Set the directory where logstash will store the tmp files before sending it to S3
   # default to the current OS temporary directory in linux /tmp/logstash
@@ -176,7 +176,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
         object = bucket.objects[remote_filename]
         object.write(fileIO,
                      :acl => @canned_acl,
-                     :server_side_encryption => @server_side_encryption ? :aes256 : nil,
+                     :server_side_encryption => @server_side_encryption,
                      :content_encoding => @encoding == "gzip" ? "gzip" : nil)
       rescue AWS::Errors::Base => error
         @logger.error("S3: AWS error", :error => error)

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -103,7 +103,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :canned_acl, :validate => ["private", "public_read", "public_read_write", "authenticated_read"],
          :default => "private"
 
-  # Specifies whether or not to use S3's AES256 server side encryption. Defaults to false.
+  # The algorithm to use for server-side encryption. Defaults to nil.
   config :server_side_encryption, :validate => ['AES256', 'aws:kms'], :default => nil
 
   # Set the directory where logstash will store the tmp files before sending it to S3


### PR DESCRIPTION
The existing implementation is not correct for V2 of the AWS SDK (looks like it's using the API from V1).

Updating the plugin to use a string instead of a boolean, which conforms to the SDK docs:
http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#server_side_encryption-instance_method