### PR TITLE
update encoding parameter in documentation

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -68,6 +68,7 @@ require "fileutils"
 #      time_file => 5                           (optional) - Minutes
 #      format => "plain"                        (optional)
 #      canned_acl => "private"                  (optional. Options are "private", "public_read", "public_read_write", "authenticated_read", "bucket_owner_full_control". Defaults to "private" )
+#      encoding => "gzip"                       (optional. Options are "none" or "gzip")
 #    }
 #
 class LogStash::Outputs::S3 < LogStash::Outputs::Base


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

The documentation for the logstash s3 output plugin does not include the encoding parameter for gzip compression found:
https://www.elastic.co/guide/en/logstash/master/plugins-outputs-s3.html
Propose update to documentation to reflect that this is now a valid option to configure.
