### PR TITLE
new concurrency model :single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
   - Move to the new concurrency model `:single`
   - use correct license identifier #99
   - add support for `bucket_owner_full_control` in the canned ACL #87
-  - dont delete plugin test files, since we only actually need the put object permission #85
+  - delete the test file but ignore any errors, because we actually only need to be able to write to S3. #97
 
 ## 3.1.2
   - Fix improper shutdown of output worker threads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 3.2.0
+  - Move to the new concurrency model `:single`
+  - use correct license identifier #99
+  - add support for `bucket_owner_full_control` in the canned ACL #87
+  - dont delete plugin test files, since we only actually need the put object permission #85
+
 ## 3.1.2
   - Fix improper shutdown of output worker threads
   - improve exception handling
+
 ## 3.0.1
  - Republish all the gems under jruby.
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -79,7 +79,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config_name "s3"
   default :codec, 'line'
 
-  concurrency :shared
+  concurrency :single
 
   # S3 bucket
   config :bucket, :validate => :string

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -258,6 +258,15 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
     begin
       write_on_bucket(test_filename)
+
+      begin
+        remote_filename = "#{@prefix}#{File.basename(test_filename)}"
+        bucket = @s3.buckets[@bucket]
+        bucket.objects[remote_filename].delete
+      rescue StandardError => e
+        # we actually only need `put_object`, but if we dont delete them
+        # we can have a lot of tests files
+      end
     ensure
       File.delete(test_filename)
     end

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -79,6 +79,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config_name "s3"
   default :codec, 'line'
 
+  concurrency :shared
+
   # S3 bucket
   config :bucket, :validate => :string
 
@@ -213,8 +215,6 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
     # required if using ruby version < 2.0
     # http://ruby.awsblog.com/post/Tx16QY1CI5GVBFT/Threading-with-the-AWS-SDK-for-Ruby
     AWS.eager_autoload!(AWS::S3)
-
-    workers_not_supported
 
     @s3 = aws_s3_config
     @upload_queue = Queue.new

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-s3'
-  s.version         = '3.1.2'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This plugin in the current state is not thread safe and we should rely to the :single delegator.