### PR TITLE
Use correct identifier for Apache License 2.0

### DIFF
--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-s3'
   s.version         = '3.1.2'
-  s.licenses        = ['Apache License (2.0)']
+  s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]


### PR DESCRIPTION
This addresses a warning during "gem build":

```
WARNING:  WARNING: license value 'Apache License 2.0' is invalid.  Use a
license identifier from http://spdx.org/licenses or 'Nonstandard' for a
nonstandard license.
```