### PR TITLE
Allow non-AWS endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.14
+  - Support for non-AWS endpoints
+
 ## 4.0.13
   - Update gemspec summary
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * Jake Landis (jakelandis)
 * Armin Braun (original-brownbear)
+* Andrew Gaul (gaul)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know


### PR DESCRIPTION
This is useful for local Ceph S3 deployments.  Fixes #10.  Fixes #65.
