### PR TITLE
Improved S3 Error logging for validation of buckets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+  - Improved Error logging for S3 validation. Now specific S3 perms errors are logged
+
 ## 4.0.0
     - This version is a complete rewrite over version 3.0.0 See #103
     - This Plugin now uses the V2 version of the SDK, this make sure we receive the latest updates and changes.

--- a/lib/logstash/outputs/s3/write_bucket_permission_validator.rb
+++ b/lib/logstash/outputs/s3/write_bucket_permission_validator.rb
@@ -7,11 +7,17 @@ module LogStash
   module Outputs
     class S3
       class WriteBucketPermissionValidator
+        include ::LogStash::Util::Loggable
+        
         def self.valid?(bucket_resource)
           begin
             upload_test_file(bucket_resource)
             true
-          rescue
+          rescue StandardError => e
+            logger.error("Error validating bucket write permissions!", 
+              :message => e.message,
+              :class => e.class.name
+              )
             false
           end
         end

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Prior to this we'd log that we couldn't write to a bucket, but didn't
give the exact API error. As seen in #110 (this does not rectify that situation however, just helps to debug it).