### PR TITLE
Fix AWS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.2
+- Fixed AWS authentication when using instance profile credentials.
+
 ## 4.0.1
   - Improved Error logging for S3 validation. Now specific S3 perms errors are logged
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ Contributors:
 * Colin Surprenant (colinsurprenant)
 * Helmut Duregger (hduregger)
 * Jordan Sissel (jordansissel)
+* Joshua Spence (joshuaspence)
 * Kurt Hurtado (kurtado)
 * Mattia Peterle (MattiaBeast)
 * Nick Ethier (nickethier)

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -253,7 +253,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   def full_options
-    options = { :credentials => credentials }
+    options = Hash.new
     options[:s3_signature_version] = @signature_version if @signature_version
     options.merge(aws_options_hash)
   end
@@ -281,7 +281,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   def bucket_resource
-    Aws::S3::Bucket.new(@bucket, { :credentials => credentials }.merge(aws_options_hash))
+    Aws::S3::Bucket.new(@bucket, full_options)
   end
 
   def aws_service_endpoint(region)

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3/file_repository_spec.rb
+++ b/spec/outputs/s3/file_repository_spec.rb
@@ -105,9 +105,6 @@ describe LogStash::Outputs::S3::FileRepository do
 
     @file_repository.get_file("another-prefix") { |file| file.write("hello") }
     expect(@file_repository.size).to eq(2)
-    @file_repository.keys.each do |k|
-      puts k
-    end
     try(10) { expect(@file_repository.size).to eq(1) }
     expect(File.directory?(path)).to be_falsey
   end

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -9,7 +9,7 @@ shared_context "setup plugin" do
   let(:time_file) { 100 }
   let(:tags) { [] }
   let(:prefix) { "home" }
-  let(:region) { "us-east-1" }
+  let(:region) { ENV['AWS_REGION'] }
 
   let(:main_options) do
     {


### PR DESCRIPTION
Fixes #110. This plugin is not currently passing the correct credentials to the AWS SDK. Instead of trying to pass in `:credentials` explicitly, we should just trust that `LogStash::PluginMixins::AwsConfig::V2#aws_options_hash` does what it is expected. Currently, the plugin is failing in one of two different ways, when using instance profile credentials.

If `validate_credentials_on_root_bucket => true`, the following error is thrown during plugin registration:

```
{"level":"ERROR","loggerName":"logstash.agent","timeMillis":1483509033892,"thread":"[main]-pipeline-manager","logEvent":{"message":"Pipeline aborted due to error","exception":{"metaClass":{"metaClass":{"metaClass":{"exception":"Logstash must have the privileges to write to root bucket `REDACTED`, check you credentials or your permissions.","backtrace":["/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-s3-4.0.1/lib/logstash/outputs/s3.rb:187:in `register'","/usr/share/logstash/logstash-core/lib/logstash/output_delegator_strategies/shared.rb:8:in `register'","/usr/share/logstash/logstash-core/lib/logstash/output_delegator.rb:37:in `register'","/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:229:in `start_workers'","org/jruby/RubyArray.java:1613:in `each'","/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:229:in `start_workers'","/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:183:in `run'","/usr/share/logstash/logstash-core/lib/logstash/agent.rb:292:in `start_pipeline'"]}}}}}}
```

If `validate_credentials_on_root_bucket => false`, the following error is thrown from the uploader threads:

```
{"level":"ERROR","loggerName":"logstash.outputs.s3","timeMillis":1483506824991,"thread":"S3 output uploader, file: /tmp/logstash/b1fe230c-3df6-40ce-8293-6cc8133ba31c/ap-southeast-2/dt=2017-01-04/ls.s3.f4fb1158-e180-4fec-b355-bafc6f388563.2017-01-03T23.22.part3.txt","logEvent":{"message":"Uploading failed, retrying","exception":{"metaClass":{"metaClass":{"metaClass":{"exception":"unable to sign request without credentials set","path":"/tmp/logstash/b1fe230c-3df6-40ce-8293-6cc8133ba31c/ap-southeast-2/dt=2017-01-04/ls.s3.f4fb1158-e180-4fec-b355-bafc6f388563.2017-01-03T23.22.part3.txt","backtrace":["/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/request_signer.rb:100:in `require_credentials'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_request_signer.rb:14:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/xml/error_handler.rb:8:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_request_signer.rb:65:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_redirects.rb:15:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/retry_errors.rb:87:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_accelerate.rb:42:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_md5s.rb:31:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_expect_100_continue.rb:21:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_bucket_name_restrictions.rb:12:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_bucket_dns.rb:31:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/rest/handler.rb:7:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/seahorse/client/plugins/endpoint.rb:41:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/param_validator.rb:21:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_sse_cpk.rb:19:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/s3_accelerate.rb:33:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/seahorse/client/plugins/response_target.rb:21:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/seahorse/client/request.rb:70:in `send_request'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-core-2.3.22/lib/seahorse/client/base.rb:207:in `create_multipart_upload'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-resources-2.3.22/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb:52:in `initiate_upload'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-resources-2.3.22/lib/aws-sdk-resources/services/s3/multipart_file_uploader.rb:43:in `upload'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-resources-2.3.22/lib/aws-sdk-resources/services/s3/file_uploader.rb:32:in `upload'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/aws-sdk-resources-2.3.22/lib/aws-sdk-resources/services/s3/object.rb:251:in `upload_file'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-s3-4.0.1/lib/logstash/outputs/s3/uploader.rb:38:in `upload'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-s3-4.0.1/lib/logstash/outputs/s3/uploader.rb:29:in `upload_async'","org/jruby/RubyProc.java:281:in `call'","/usr/share/logstash/vendor/bundle/jruby/1.9/gems/concurrent-ruby-1.0.0-java/lib/concurrent/executor/java_executor_service.rb:94:in `run'","Concurrent$$JavaExecutorService$$Job_1168525423.gen:13:in `run'"]}}}}}}
```