### PR TITLE
Typo in cannel_acl usage for the upload options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,30 @@
+## 4.0.3
+  - When configuring the `canned_acl` options of the plugins the role was not applied correctly to the created object: #7
+
 ## 4.0.2
-- Fixed AWS authentication when using instance profile credentials.
+  - Fixed AWS authentication when using instance profile credentials.
 
 ## 4.0.1
   - Improved Error logging for S3 validation. Now specific S3 perms errors are logged
 
 ## 4.0.0
-    - This version is a complete rewrite over version 3.0.0 See #103
-    - This Plugin now uses the V2 version of the SDK, this make sure we receive the latest updates and changes.
-    - We now uses S3's `upload_file` instead of reading chunks, this method is more efficient and will uses the multipart with threads if the files is too big.
-    - You can now use the `fieldref` syntax in the prefix to dynamically changes the target with the events it receives.
-    - The Upload queue is now a bounded list, this options is necessary to allow back pressure to be communicated back to the pipeline but its configurable by the user.
-    - If the queue is full the plugin will start the upload in the current thread.
-    - The plugin now threadsafe and support the concurrency model `shared`
-    - The rotation strategy can be selected, the recommended is `size_and_time` that will check for both the configured limits (`size` and `time` are also available)
-    - The `restore` option will now use a separate threadpool with an unbounded queue
-    - The `restore` option will not block the launch of logstash and will uses less resources than the real time path
-    - The plugin now uses `multi_receive_encode`, this will optimize the writes to the files
-    - rotate operation are now batched to reduce the number of IO calls.
-    - Empty file will not be uploaded by any rotation rotation strategy
-    - We now use Concurrent-Ruby for the implementation of the java executor
-    - If you have finer grain permission on prefixes or want faster boot, you can disable the credentials check with `validate_credentials_on_root_bucket`
-    - The credentials check will no longer fails if we can't delete the file
-    - We now have a full suite of integration test for all the defined rotation
+  - This version is a complete rewrite over version 3.0.0 See #103
+  - This Plugin now uses the V2 version of the SDK, this make sure we receive the latest updates and changes.
+  - We now uses S3's `upload_file` instead of reading chunks, this method is more efficient and will uses the multipart with threads if the files is too big.
+  - You can now use the `fieldref` syntax in the prefix to dynamically changes the target with the events it receives.
+  - The Upload queue is now a bounded list, this options is necessary to allow back pressure to be communicated back to the pipeline but its configurable by the user.
+  - If the queue is full the plugin will start the upload in the current thread.
+  - The plugin now threadsafe and support the concurrency model `shared`
+  - The rotation strategy can be selected, the recommended is `size_and_time` that will check for both the configured limits (`size` and `time` are also available)
+  - The `restore` option will now use a separate threadpool with an unbounded queue
+  - The `restore` option will not block the launch of logstash and will uses less resources than the real time path
+  - The plugin now uses `multi_receive_encode`, this will optimize the writes to the files
+  - rotate operation are now batched to reduce the number of IO calls.
+  - Empty file will not be uploaded by any rotation rotation strategy
+  - We now use Concurrent-Ruby for the implementation of the java executor
+  - If you have finer grain permission on prefixes or want faster boot, you can disable the credentials check with `validate_credentials_on_root_bucket`
+  - The credentials check will no longer fails if we can't delete the file
+  - We now have a full suite of integration test for all the defined rotation
 
 Fixes: #4 #81 #44 #59 #50
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -262,6 +262,14 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
     prefix_key.gsub(PathValidator.matches_re, PREFIX_KEY_NORMALIZE_CHARACTER)
   end
 
+  def upload_options
+    {
+      :acl => @canned_acl,
+      :server_side_encryption => @server_side_encryption ? :aes256 : nil,
+      :content_encoding => @encoding == "gzip" ? "gzip" : nil
+    }
+  end
+
   private
   # We start a task in the background for check for stale files and make sure we rotate them to S3 if needed.
   def start_periodic_check
@@ -286,14 +294,6 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   def aws_service_endpoint(region)
     { :s3_endpoint => region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"}
-  end
-
-  def upload_options
-    {
-      :acl => @cannel_acl,
-      :server_side_encryption => @server_side_encryption ? :aes256 : nil,
-      :content_encoding => @encoding == "gzip" ? "gzip" : nil
-    }
   end
 
   def rotate_if_needed(prefixes)

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -43,6 +43,24 @@ describe LogStash::Outputs::S3 do
       end
     end
 
+    describe "Access control list" do
+      context "when configured" do
+        ["private", "public_read", "public_read_write", "authenticated_read"].each do |permission|
+          it "should return the configured ACL permissions: #{permission}" do
+            s3 = described_class.new(options.merge({ "canned_acl" => permission }))
+            expect(s3.upload_options).to include(:acl => permission)
+          end
+        end
+      end
+
+      context "when not configured" do
+        it "uses private as the default" do
+          s3 = described_class.new(options)
+          expect(s3.upload_options).to include(:acl => "private")
+        end
+      end
+    end
+
     describe "temporary directory" do
       let(:temporary_directory) { Stud::Temporary.pathname }
       let(:options) { super.merge({ "temporary_directory" => temporary_directory }) }


### PR DESCRIPTION
The code was referring to `@cannel_acl` instead of `@canned_acl` making the configured not correctly applied to the object.

Fix a layout issue in the changelog.