### PR TITLE
Correctly cleanup file when a S3 upload is succesfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+  - Delete the file on disk after they are succesfully uploaded to S3 #122 #120
+  - Added logging when an exception occur in the Uploader's `on_complete` callback
+
 ## 4.0.4
   - Add support for `storage_class` configuration
   - Fix compatibility with Logstash 2.4

--- a/lib/logstash/outputs/s3/temporary_file.rb
+++ b/lib/logstash/outputs/s3/temporary_file.rb
@@ -50,8 +50,8 @@ module LogStash
         # we delete the root of the UUID, using a UUID also remove the risk of deleting unwanted file, it acts as
         # a sandbox.
         def delete!
-          @fd.close
-          ::FileUtils.rm_rf(@temp_path, :secure => true)
+          @fd.close rescue IOError # force close anyway
+          FileUtils.rm_rf(@temp_path, :secure => true)
         end
 
         def empty?

--- a/lib/logstash/outputs/s3/uploader.rb
+++ b/lib/logstash/outputs/s3/uploader.rb
@@ -42,11 +42,14 @@ module LogStash
             #
             # Thread might be stuck here, but I think its better than losing anything
             # its either a transient errors or something bad really happened.
-            logger.error("Uploading failed, retrying", :exception => e, :path => file.path, :backtrace => e.backtrace)
+            logger.error("Uploading failed, retrying", :exception => e.class, :message => e.message, :path => file.path, :backtrace => e.backtrace)
             retry
           end
 
           options[:on_complete].call(file) unless options[:on_complete].nil?
+        rescue => e
+          logger.error("An error occured in the `on_complete` uploader", :exception => e.class, :message => e.message, :path => file.path, :backtrace => e.backtrace)
+          raise e # reraise it since we don't deal with it now
         end
 
         def stop

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.4'
+  s.version         = '4.0.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/time_based_rotation_with_stale_write_spec.rb
+++ b/spec/integration/time_based_rotation_with_stale_write_spec.rb
@@ -26,7 +26,7 @@ describe "File Time rotation with stale write", :integration => true do
     clean_remote_files(prefix)
     subject.register
     subject.multi_receive_encoded(batch)
-    sleep(1) # the periodic check should have kick int
+    sleep(5) # the periodic check should have kick in
   end
 
   after do
@@ -55,6 +55,10 @@ describe "File Time rotation with stale write", :integration => true do
 
     try(20) do
       expect(Dir.glob(File.join(download_directory, "**", "*.txt")).inject(0) { |sum, f| sum + IO.readlines(f).size }).to eq(number_of_events)
+    end
+
+    try(10) do
+      expect(Dir.glob(File.join(temporary_directory, "**", "*.txt")).size).to eq(1) # we should only have 1 file left, since we did a rotation
     end
   end
 end

--- a/spec/outputs/s3/temporary_file_spec.rb
+++ b/spec/outputs/s3/temporary_file_spec.rb
@@ -34,6 +34,13 @@ describe LogStash::Outputs::S3::TemporaryFile do
     expect(File.exist?(subject.path)).to be_falsey
   end
 
+  it "successfully delete a file already closed" do
+    subject.close
+    expect(File.exist?(subject.path)).to be_truthy
+    subject.delete!
+    expect(File.exist?(subject.path)).to be_falsey
+  end
+
   it "returns the creation time" do
     expect(subject.ctime).to be < Time.now + 0.5
   end


### PR DESCRIPTION
The TemporaryFile#delete! method was raising an exception because we
were trying to close a file that was already close, since the
`on_complete` is executed in a thread nothing was present to catch and
log that specific error and the thread would just end up getting killed.

This PR add guards for closing an already close file, also add test
around the stale file uploader checker to make sure only 1 file is
remaining on disk after rotation.

For future debugging we also log any error that can occur in the
uploader callback.

Fixes: #122 #120