### PR TITLE
Use GzipWriter.pos to get file size for gzip encoded files

### DIFF
--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -115,7 +115,7 @@ module LogStash
               0
             else
               @gzip_writer.flush
-              @gzip_writer.to_io.size_file
+              @gzip_writer.to_io.size
             end
           end
 

--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -109,7 +109,14 @@ module LogStash
 
           def size
             # to get the current file size
-            @gzip_writer.pos
+            if @gzip_writer.pos == 0
+              # Ensure a zero file size is returned when nothing has
+              # yet been written to the gzip file.
+              0
+            else
+              @gzip_writer.flush
+              @gzip_writer.to_io.size_file
+            end
           end
 
           def fsync

--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -109,8 +109,7 @@ module LogStash
 
           def size
             # to get the current file size
-            @gzip_writer.flush
-            @gzip_writer.to_io.size
+            @gzip_writer.pos
           end
 
           def fsync

--- a/spec/outputs/s3/temporary_file_factory_spec.rb
+++ b/spec/outputs/s3/temporary_file_factory_spec.rb
@@ -20,6 +20,10 @@ describe LogStash::Outputs::S3::TemporaryFileFactory do
       expect(File.exist?(subject.current.path)).to be_truthy
     end
 
+    it "returns a size equal to zero after file creation" do
+      expect(subject.current.size).to eq(0)
+    end
+
     it "create a temporary file when initialized" do
       expect(subject.current).to be_kind_of(LogStash::Outputs::S3::TemporaryFile)
     end


### PR DESCRIPTION
This pull request fixes the issue where empty gzip files were being uploaded to S3 when using the gzip encoding.  The root of the problem is that a gzip file has a non-zero size even right after it is opened.  To solve the issue we make use of the `pos()` function of the `GZipWriter` class.  See https://ruby-doc.org/stdlib-1.9.3/libdoc/zlib/rdoc/Zlib/GzipWriter.html. 

I first created a simple test case that exposed the bug, and then verified that my proposed solution takes care of the problem. 
