### PR TITLE
S3 Client Signature Version Attribute Name

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ The following is a list of people who have contributed ideas, code, bug
 reports, or in general have helped logstash along its way.
 
 Contributors:
+* Chad Bean (chadbean)
 * Colin Surprenant (colinsurprenant)
 * Helmut Duregger (hduregger)
 * Jordan Sissel (jordansissel)

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -268,7 +268,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   def full_options
     options = Hash.new
-    options[:s3_signature_version] = @signature_version if @signature_version
+    options[:signature_version] = @signature_version if @signature_version
     options.merge(aws_options_hash)
   end
 

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -33,13 +33,13 @@ describe LogStash::Outputs::S3 do
       it "should set the signature version if specified" do
         ["v2", "v4"].each do |version|
           s3 = described_class.new(options.merge({ "signature_version" => version }))
-          expect(s3.full_options).to include(:s3_signature_version => version)
+          expect(s3.full_options).to include(:signature_version => version)
         end
       end
 
       it "should omit the option completely if not specified" do
         s3 = described_class.new(options)
-        expect(s3.full_options.has_key?(:s3_signature_version)).to eql(false)
+        expect(s3.full_options.has_key?(:signature_version)).to eql(false)
       end
     end
 


### PR DESCRIPTION
It looks like the attribute `s3_signature_version` was part of the AWS Ruby SDK v1. The v2 SDK uses `signature_version` as the attribute name. Essentially this fixes an issue where I was unable to send the logs to a bucket.

> Ruby SDK - Version 2: Set the signature_version parameter to v4 when constructing the client.
> s3 = Aws::S3::Client.new(signature_version: 'v4')

See: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version

