### PR TITLE
Fixes issues with the `canned_acl` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.7
+  - Fix: `#restore_from_crash` should use the same upload options as the normal uploader. #140
+  - Fix: Wrongly named `canned_acl` options, renamed to "public-read", "public-read-write", "authenticated-read", from the documentation http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+
 ## 4.0.6
   - Fix: Use the right `signature_version` for the SDK v2 #129
   - Fix an issue to prevent the output to upload empty file to S3 #128

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -72,7 +72,7 @@ Aws.eager_autoload!
 #      size_file => 2048                        (optional) - Bytes
 #      time_file => 5                           (optional) - Minutes
 #      codec => "plain"                         (optional)
-#      canned_acl => "private"                  (optional. Options are "private", "public_read", "public_read_write", "authenticated_read". Defaults to "private" )
+#      canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read". Defaults to "private" )
 #    }
 #
 class LogStash::Outputs::S3 < LogStash::Outputs::Base
@@ -124,7 +124,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :restore, :validate => :boolean, :default => true
 
   # The S3 canned ACL to use when putting the file. Defaults to "private".
-  config :canned_acl, :validate => ["private", "public_read", "public_read_write", "authenticated_read"],
+  config :canned_acl, :validate => ["private", "public-read", "public-read-write", "authenticated-read"],
          :default => "private"
 
   # Specifies wether or not to use S3's server side encryption. Defaults to no encryption.
@@ -372,7 +372,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
       .each do |file|
       temp_file = TemporaryFile.create_from_existing_file(file, temp_folder_path)
       @logger.debug("Recovering from crash and uploading", :file => temp_file.path)
-      @crash_uploader.upload_async(temp_file, :on_complete => method(:clean_temporary_file))
+      @crash_uploader.upload_async(temp_file, :on_complete => method(:clean_temporary_file), :upload_options => upload_options)
     end
   end
 end

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.6'
+  s.version         = '4.0.7'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/restore_from_crash_spec.rb
+++ b/spec/integration/restore_from_crash_spec.rb
@@ -7,7 +7,7 @@ require "stud/temporary"
 describe "Restore from crash", :integration => true do
   include_context "setup plugin"
 
-  let(:options) { main_options.merge({ "restore" => true }) }
+  let(:options) { main_options.merge({ "restore" => true, "canned_acl" => "public-read-write" }) }
 
   let(:number_of_files) { 5 }
   let(:dummy_content) { "foobar\n" * 100 }
@@ -33,6 +33,7 @@ describe "Restore from crash", :integration => true do
     try(20) do
       expect(bucket_resource.objects(:prefix => prefix).count).to eq(number_of_files)
       expect(Dir.glob(File.join(temporary_directory, "*")).size).to eq(0)
+      expect(bucket_resource.objects(:prefix => prefix).first.acl.grants.collect(&:permission)).to include("READ", "WRITE")
     end
   end
 end

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -45,7 +45,7 @@ describe LogStash::Outputs::S3 do
 
     describe "Access control list" do
       context "when configured" do
-        ["private", "public_read", "public_read_write", "authenticated_read"].each do |permission|
+        ["private", "public-read", "public-read-write", "authenticated-read"].each do |permission|
           it "should return the configured ACL permissions: #{permission}" do
             s3 = described_class.new(options.merge({ "canned_acl" => permission }))
             expect(s3.upload_options).to include(:acl => permission)


### PR DESCRIPTION
The list of canned acl was not the official one and made the push of
document to S3 fail, this could be considered to be a backward
incompatible changes but if you used something else than private it
would not have worked correctly.

Fix an issue with the `canned_acl` not correctly passed to the crash
uploader when the `restore` option was set to true

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
