### PR TITLE
Add "bucket-owner-full-control" canned ACL

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -64,7 +64,7 @@ output {
      size_file => 2048                        (optional) - Bytes
      time_file => 5                           (optional) - Minutes
      codec => "plain"                         (optional)
-     canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read". Defaults to "private" )
+     canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-full-control". Defaults to "private" )
    }
 
 
@@ -79,7 +79,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-access_key_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-canned_acl>> |<<string,string>>, one of `["private", "public-read", "public-read-write", "authenticated-read"]`|No
+| <<plugins-{type}s-{plugin}-canned_acl>> |<<string,string>>, one of `["private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-full-control"]`|No
 | <<plugins-{type}s-{plugin}-encoding>> |<<string,string>>, one of `["none", "gzip"]`|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
@@ -107,7 +107,7 @@ output plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-access_key_id"]
-===== `access_key_id` 
+===== `access_key_id`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -121,7 +121,7 @@ This plugin uses the AWS SDK and supports several ways to get credentials, which
 5. IAM Instance Profile (available when running inside EC2)
 
 [id="plugins-{type}s-{plugin}-aws_credentials_file"]
-===== `aws_credentials_file` 
+===== `aws_credentials_file`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -139,7 +139,7 @@ file should look like this:
 
 
 [id="plugins-{type}s-{plugin}-bucket"]
-===== `bucket` 
+===== `bucket`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -148,15 +148,15 @@ file should look like this:
 S3 bucket
 
 [id="plugins-{type}s-{plugin}-canned_acl"]
-===== `canned_acl` 
+===== `canned_acl`
 
-  * Value can be any of: `private`, `public-read`, `public-read-write`, `authenticated-read`
+  * Value can be any of: `private`, `public-read`, `public-read-write`, `authenticated-read`, `bucket-owner-full-control`
   * Default value is `"private"`
 
 The S3 canned ACL to use when putting the file. Defaults to "private".
 
 [id="plugins-{type}s-{plugin}-encoding"]
-===== `encoding` 
+===== `encoding`
 
   * Value can be any of: `none`, `gzip`
   * Default value is `"none"`
@@ -164,7 +164,7 @@ The S3 canned ACL to use when putting the file. Defaults to "private".
 Specify the content encoding. Supports ("gzip"). Defaults to "none"
 
 [id="plugins-{type}s-{plugin}-prefix"]
-===== `prefix` 
+===== `prefix`
 
   * Value type is <<string,string>>
   * Default value is `""`
@@ -173,7 +173,7 @@ Specify a prefix to the uploaded filename, this can simulate directories on S3. 
 This option support string interpolation, be warned this can created a lot of temporary local files.
 
 [id="plugins-{type}s-{plugin}-proxy_uri"]
-===== `proxy_uri` 
+===== `proxy_uri`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -181,7 +181,7 @@ This option support string interpolation, be warned this can created a lot of te
 URI to proxy server if required
 
 [id="plugins-{type}s-{plugin}-region"]
-===== `region` 
+===== `region`
 
   * Value can be any of: `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`, `eu-central-1`, `eu-west-1`, `eu-west-2`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `ap-northeast-2`, `sa-east-1`, `us-gov-west-1`, `cn-north-1`, `ap-south-1`, `ca-central-1`
   * Default value is `"us-east-1"`
@@ -189,7 +189,7 @@ URI to proxy server if required
 The AWS Region
 
 [id="plugins-{type}s-{plugin}-restore"]
-===== `restore` 
+===== `restore`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -197,7 +197,7 @@ The AWS Region
 
 
 [id="plugins-{type}s-{plugin}-rotation_strategy"]
-===== `rotation_strategy` 
+===== `rotation_strategy`
 
   * Value can be any of: `size_and_time`, `size`, `time`
   * Default value is `"size_and_time"`
@@ -206,7 +206,7 @@ Define the strategy to use to decide when we need to rotate the file and push it
 The default strategy is to check for both size and time, the first one to match will rotate the file.
 
 [id="plugins-{type}s-{plugin}-secret_access_key"]
-===== `secret_access_key` 
+===== `secret_access_key`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -214,7 +214,7 @@ The default strategy is to check for both size and time, the first one to match 
 The AWS Secret Access Key
 
 [id="plugins-{type}s-{plugin}-server_side_encryption"]
-===== `server_side_encryption` 
+===== `server_side_encryption`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -222,7 +222,7 @@ The AWS Secret Access Key
 Specifies wether or not to use S3's server side encryption. Defaults to no encryption.
 
 [id="plugins-{type}s-{plugin}-server_side_encryption_algorithm"]
-===== `server_side_encryption_algorithm` 
+===== `server_side_encryption_algorithm`
 
   * Value can be any of: `AES256`, `aws:kms`
   * Default value is `"AES256"`
@@ -230,7 +230,7 @@ Specifies wether or not to use S3's server side encryption. Defaults to no encry
 Specifies what type of encryption to use when SSE is enabled.
 
 [id="plugins-{type}s-{plugin}-session_token"]
-===== `session_token` 
+===== `session_token`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -238,7 +238,7 @@ Specifies what type of encryption to use when SSE is enabled.
 The AWS Session token for temporary credential
 
 [id="plugins-{type}s-{plugin}-signature_version"]
-===== `signature_version` 
+===== `signature_version`
 
   * Value can be any of: `v2`, `v4`
   * There is no default value for this setting.
@@ -247,7 +247,7 @@ The version of the S3 signature hash to use. Normally uses the internal client d
 specified here
 
 [id="plugins-{type}s-{plugin}-size_file"]
-===== `size_file` 
+===== `size_file`
 
   * Value type is <<number,number>>
   * Default value is `5242880`
@@ -256,7 +256,7 @@ Set the size of file in bytes, this means that files on bucket when have dimensi
 If you have tags then it will generate a specific size file for every tags
 
 [id="plugins-{type}s-{plugin}-ssekms_key_id"]
-===== `ssekms_key_id` 
+===== `ssekms_key_id`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -266,7 +266,7 @@ If server_side_encryption => aws:kms is set but this is not default KMS key is u
 http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 
 [id="plugins-{type}s-{plugin}-storage_class"]
-===== `storage_class` 
+===== `storage_class`
 
   * Value can be any of: `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`
   * Default value is `"STANDARD"`
@@ -277,7 +277,7 @@ http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html
 Defaults to STANDARD.
 
 [id="plugins-{type}s-{plugin}-temporary_directory"]
-===== `temporary_directory` 
+===== `temporary_directory`
 
   * Value type is <<string,string>>
   * Default value is `"/tmp/logstash"`
@@ -286,7 +286,7 @@ Set the directory where logstash will store the tmp files before sending it to S
 default to the current OS temporary directory in linux /tmp/logstash
 
 [id="plugins-{type}s-{plugin}-time_file"]
-===== `time_file` 
+===== `time_file`
 
   * Value type is <<number,number>>
   * Default value is `15`
@@ -297,7 +297,7 @@ If you define file_size you have a number of files in consideration of the secti
 for now the only thing this plugin can do is to put the file when logstash restart.
 
 [id="plugins-{type}s-{plugin}-upload_queue_size"]
-===== `upload_queue_size` 
+===== `upload_queue_size`
 
   * Value type is <<number,number>>
   * Default value is `4`
@@ -305,7 +305,7 @@ for now the only thing this plugin can do is to put the file when logstash resta
 Number of items we can keep in the local queue before uploading them
 
 [id="plugins-{type}s-{plugin}-upload_workers_count"]
-===== `upload_workers_count` 
+===== `upload_workers_count`
 
   * Value type is <<number,number>>
   * Default value is `4`
@@ -313,7 +313,7 @@ Number of items we can keep in the local queue before uploading them
 Specify how many workers to use to upload the files to S3
 
 [id="plugins-{type}s-{plugin}-validate_credentials_on_root_bucket"]
-===== `validate_credentials_on_root_bucket` 
+===== `validate_credentials_on_root_bucket`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -72,7 +72,7 @@ Aws.eager_autoload!
 #      size_file => 2048                        (optional) - Bytes
 #      time_file => 5                           (optional) - Minutes
 #      codec => "plain"                         (optional)
-#      canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read". Defaults to "private" )
+#      canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-full-control". Defaults to "private" )
 #    }
 #
 class LogStash::Outputs::S3 < LogStash::Outputs::Base
@@ -124,7 +124,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :restore, :validate => :boolean, :default => true
 
   # The S3 canned ACL to use when putting the file. Defaults to "private".
-  config :canned_acl, :validate => ["private", "public-read", "public-read-write", "authenticated-read"],
+  config :canned_acl, :validate => ["private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-full-control"],
          :default => "private"
 
   # Specifies wether or not to use S3's server side encryption. Defaults to no encryption.

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -45,7 +45,7 @@ describe LogStash::Outputs::S3 do
 
     describe "Access control list" do
       context "when configured" do
-        ["private", "public-read", "public-read-write", "authenticated-read"].each do |permission|
+        ["private", "public-read", "public-read-write", "authenticated-read", "bucket-owner-full-control"].each do |permission|
           it "should return the configured ACL permissions: #{permission}" do
             s3 = described_class.new(options.merge({ "canned_acl" => permission }))
             expect(s3.upload_options).to include(:acl => permission)


### PR DESCRIPTION
Add support for the `bucket-owner-full-control` ACL. It's very useful when you are writing files in a bucket owned by a different AWS account.