### PR TITLE
#156 added missing interface include to FactoryInitializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.11
+ - Fixed a randomly occurring error that logged as a missing `__jcreate_meta` method
+
 ## 4.0.10
   - Fix some documentation issues
 

--- a/lib/logstash/outputs/s3/file_repository.rb
+++ b/lib/logstash/outputs/s3/file_repository.rb
@@ -41,6 +41,7 @@ module LogStash
         end
 
         class FactoryInitializer
+          include java.util.function.Function
           def initialize(tags, encoding, temporary_directory, stale_time)
             @tags = tags
             @encoding = encoding

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.0.10'
+  s.version         = '4.0.11'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This plugin was created for store the logstash's events into Amazon Simple Storage Service (Amazon S3)"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #156 `FactoryInitializer` is effectively implementing a Java interface here by being passed into `java.util.concurrent.ConcurrentHashMap#computeIfAbsent`.
It seems to me the automatic handling of the correct interface is only going to work properly for blocks and procs, not for any object instance, leading to the auto interface wrapping breaking here https://github.com/jruby/jruby/blob/c26fe1ba92acad0de01273d4711711f8e2e690ec/core/src/main/java/org/jruby/javasupport/JavaUtil.java#L251.

=> Fixed by including the interface