### PR TITLE
Add more S3 bucket ACLs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -64,7 +64,7 @@ output {
      size_file => 2048                        (optional) - Bytes
      time_file => 5                           (optional) - Minutes
      codec => "plain"                         (optional)
-     canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read". Defaults to "private" )
+     canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write". Defaults to "private" )
    }
 
 
@@ -79,7 +79,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-access_key_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-canned_acl>> |<<string,string>>, one of `["private", "public-read", "public-read-write", "authenticated-read"]`|No
+| <<plugins-{type}s-{plugin}-canned_acl>> |<<string,string>>, one of `["private", "public-read", "public-read-write", "authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"]`|No
 | <<plugins-{type}s-{plugin}-encoding>> |<<string,string>>, one of `["none", "gzip"]`|No
 | <<plugins-{type}s-{plugin}-prefix>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
@@ -150,7 +150,7 @@ S3 bucket
 [id="plugins-{type}s-{plugin}-canned_acl"]
 ===== `canned_acl` 
 
-  * Value can be any of: `private`, `public-read`, `public-read-write`, `authenticated-read`
+  * Value can be any of: `private`, `public-read`, `public-read-write`, `authenticated-read`, `aws-exec-read`, `bucket-owner-read`, `bucket-owner-full-control`, `log-delivery-write`
   * Default value is `"private"`
 
 The S3 canned ACL to use when putting the file. Defaults to "private".

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -72,7 +72,7 @@ Aws.eager_autoload!
 #      size_file => 2048                        (optional) - Bytes
 #      time_file => 5                           (optional) - Minutes
 #      codec => "plain"                         (optional)
-#      canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read". Defaults to "private" )
+#      canned_acl => "private"                  (optional. Options are "private", "public-read", "public-read-write", "authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write". Defaults to "private" )
 #    }
 #
 class LogStash::Outputs::S3 < LogStash::Outputs::Base
@@ -124,7 +124,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :restore, :validate => :boolean, :default => true
 
   # The S3 canned ACL to use when putting the file. Defaults to "private".
-  config :canned_acl, :validate => ["private", "public-read", "public-read-write", "authenticated-read"],
+  config :canned_acl, :validate => ["private", "public-read", "public-read-write", "authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"],
          :default => "private"
 
   # Specifies wether or not to use S3's server side encryption. Defaults to no encryption.

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -45,7 +45,7 @@ describe LogStash::Outputs::S3 do
 
     describe "Access control list" do
       context "when configured" do
-        ["private", "public-read", "public-read-write", "authenticated-read"].each do |permission|
+        ["private", "public-read", "public-read-write", "authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"].each do |permission|
           it "should return the configured ACL permissions: #{permission}" do
             s3 = described_class.new(options.merge({ "canned_acl" => permission }))
             expect(s3.upload_options).to include(:acl => permission)


### PR DESCRIPTION
There are more canned ACL's available, and I would like to use them when storing logs.

Expands #152 Resolves #76 