### PR TITLE
Symbolize additional_settings hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.2
+  - Symbolize hash keys for additional_settings hash #179
+
 ## 4.1.1
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -271,8 +271,20 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   def full_options
     options = aws_options_hash || {}
     options[:signature_version] = @signature_version if @signature_version
-    @additional_settings.merge(options)
+    symbolized_settings.merge(options)
   end
+
+  def symbolized_settings
+    @symbolized_settings ||= symbolize_keys(@additional_settings)
+  end
+
+  def symbolize_keys(hash)
+    return hash unless hash.is_a?(Hash)
+    symbolized = {}
+    hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys(value) }
+    symbolized
+  end
+
 
   def normalize_key(prefix_key)
     prefix_key.gsub(PathValidator.matches_re, PREFIX_KEY_NORMALIZE_CHARACTER)

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Sends Logstash events to the Amazon Simple Storage Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -149,7 +149,7 @@ describe LogStash::Outputs::S3 do
         end
 
         it "validates the prefix" do
-          expect(Aws::S3::Bucket).to receive(:new).twice.with(anything, hash_including("force_path_style" => true)).and_call_original
+          expect(Aws::S3::Bucket).to receive(:new).twice.with(anything, hash_including(:force_path_style => true)).and_call_original
           described_class.new(options.merge(additional_settings)).register
         end
       end


### PR DESCRIPTION
AWS SDK expects symbolized hash keys, so do that.
