### PR TITLE
Fix documentation for s3 output

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,8 +58,8 @@ This is an example of logstash config:
 [source,ruby]
 output {
    s3{
-     access_key_id => "crazy_key"             (required)
-     secret_access_key => "monkey_access_key" (required)
+     access_key_id => "crazy_key"             (optional)
+     secret_access_key => "monkey_access_key" (optional)
      region => "eu-west-1"                    (optional, default = "us-east-1")
      bucket => "your_bucket"                  (required)
      size_file => 2048                        (optional) - Bytes


### PR DESCRIPTION
The example configuration lists `access_key_id` and `secret_access_key` as required parameters, but later references in the documentation contradict that [here](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-s3.html#plugins-outputs-s3-options) and [here](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-s3.html#plugins-outputs-s3-access_key_id).

This changes the `(required)` comments to `(optional)`.