### PR TITLE
Fix bucket permission validation upload options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.5
+  - Fixed bucket validation failures when bucket policy requires encryption [#191](https://github.com/logstash-plugins/logstash-output-s3/pull/191)
+
 ## 4.1.4
   - [#185](https://github.com/logstash-plugins/logstash-output-s3/pull/184) Internal: Revert rake pinning to fix upstream builds
 

--- a/lib/logstash/outputs/s3/write_bucket_permission_validator.rb
+++ b/lib/logstash/outputs/s3/write_bucket_permission_validator.rb
@@ -15,7 +15,7 @@ module LogStash
 
         def valid?(bucket_resource, upload_options = {})
           begin
-            upload_test_file(bucket_resource)
+            upload_test_file(bucket_resource, upload_options)
             true
           rescue StandardError => e
             logger.error("Error validating bucket write permissions!",

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.1.4'
+  s.version         = '4.1.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Sends Logstash events to the Amazon Simple Storage Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3/write_bucket_permission_validator_spec.rb
+++ b/spec/outputs/s3/write_bucket_permission_validator_spec.rb
@@ -17,6 +17,16 @@ describe LogStash::Outputs::S3::WriteBucketPermissionValidator do
     expect(bucket).to receive(:object).with(any_args).and_return(obj)
   end
 
+  context 'when using upload_options' do
+    let(:upload_options) {{ :server_side_encryption => true }}
+    it 'they are passed through to upload_file' do
+      expect(obj).to receive(:upload_file).with(anything, upload_options)
+      expect(obj).to receive(:delete).and_return(true)
+      expect(subject.valid?(bucket, upload_options)).to be_truthy
+    end
+
+  end
+
   context "when permissions are sufficient" do
     it "returns true" do
       expect(obj).to receive(:upload_file).with(any_args).and_return(true)


### PR DESCRIPTION
Pass 'upload_options' hash through to the bucket upload_test_file method to
fix issues where permission errors were happening when trying to validate
permissions on buckets with an 'encryption required' policy.

Fixes #188, #146, #132