### PR TITLE
Adding possibility to include file name as a part of prefix

### DIFF
--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -24,11 +24,18 @@ module LogStash
         TXT_EXTENSION = "txt"
         STRFTIME = "%Y-%m-%dT%H.%M"
 
-        attr_accessor :counter, :tags, :prefix, :encoding, :temporary_directory, :current
+        attr_accessor :counter, :tags, :prefix, :encoding, :temporary_directory, :current, :fname
 
         def initialize(prefix, tags, encoding, temporary_directory)
           @counter = 0
-          @prefix = prefix
+          lsl = prefix.rindex('/')
+          if lsl.nil? or lsl == prefix.size - 1 then
+              @prefix = prefix
+              @fname = nil
+          else
+              @prefix = prefix.slice(0, lsl + 1)
+              @fname = prefix.slice(lsl + 1, prefix.size)
+          end
 
           @tags = tags
           @encoding = encoding
@@ -75,7 +82,7 @@ module LogStash
 
         def new_file
           uuid = SecureRandom.uuid
-          name = generate_name
+          name = fname.nil? ? generate_name : fname
           path = ::File.join(temporary_directory, uuid)
           key = ::File.join(prefix, name)
 

--- a/spec/outputs/s3/temporary_file_factory_spec.rb
+++ b/spec/outputs/s3/temporary_file_factory_spec.rb
@@ -58,6 +58,18 @@ describe LogStash::Outputs::S3::TemporaryFileFactory do
       expect(subject.current.path).to include(uuid)
     end
 
+    context "with prefix contains /" do
+      subject { described_class.new('prefix/filename.ext', tags, encoding, temporary_directory) }
+      it "is initialized with filename" do
+        expect(subject.prefix).to eq('prefix/')
+        expect(subject.fname).to eq('filename.ext')
+      end
+      it "should return file name as current filename" do
+        file = subject.current
+        expect(file.path).to end_with "prefix/filename.ext"
+      end
+    end
+
     context "with tags supplied" do
       let(:tags) { ["secret", "service"] }
 


### PR DESCRIPTION
Sometimes it's necessary to put each log event into separate file in s3 with an exact file name formed from an event fields. The existing "prefix" property can be used for that 