### PR TITLE
Refactor: cleanup unused (old) method

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -326,10 +326,6 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
     Aws::S3::Bucket.new(@bucket, full_options)
   end
 
-  def aws_service_endpoint(region)
-    { :s3_endpoint => region == 'us-east-1' ? 's3.amazonaws.com' : "s3-#{region}.amazonaws.com"}
-  end
-
   def rotate_if_needed(prefixes)
     prefixes.each do |prefix|
       # Each file access is thread safe,

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -204,4 +204,27 @@ describe LogStash::Outputs::S3 do
       subject.multi_receive_encoded(events_and_encoded)
     end
   end
+
+  describe "aws service" do
+    context 'us-east-1' do
+      let(:region) { 'us-east-1' }
+      it "sets endpoint" do
+        expect( subject.send(:bucket_resource).client.config.endpoint.to_s ).to eql 'https://s3.us-east-1.amazonaws.com'
+      end
+    end
+
+    context 'us-east-1' do
+      let(:region) { 'ap-east-1' }
+      it "sets endpoint" do
+        expect( subject.send(:bucket_resource).client.config.endpoint.to_s ).to eql 'https://s3.ap-east-1.amazonaws.com'
+      end
+    end
+
+    context 'cn-northwest-1' do
+      let(:region) { 'cn-northwest-1' }
+      it "sets endpoint" do
+        expect( subject.send(:bucket_resource).client.config.endpoint.to_s ).to eql 'https://s3.cn-northwest-1.amazonaws.com.cn'
+      end
+    end
+  end
 end

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -213,7 +213,7 @@ describe LogStash::Outputs::S3 do
       end
     end
 
-    context 'us-east-1' do
+    context 'ap-east-1' do
       let(:region) { 'ap-east-1' }
       it "sets endpoint" do
         expect( subject.send(:bucket_resource).client.config.endpoint.to_s ).to eql 'https://s3.ap-east-1.amazonaws.com'


### PR DESCRIPTION
- cleanup unused (old) methods
  was used in V1 - no longer relevant with aws-sdk 2.x (explanation at https://github.com/logstash-plugins/logstash-output-s3/pull/108#issuecomment-582339375)
  (since its private it never got to be called from the mixin)

with https://github.com/logstash-plugins/logstash-mixin-aws/pull/42 this caused some aws gem newbie confusion ...
