### PR TITLE
Feat: Added retry_count and retry_delay config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.0
+  -  Feat: Added retry_count and retry_delay config [#218](https://github.com/logstash-plugins/logstash-output-s3/pull/218)
+
 ## 4.2.0
   - Added ability to specify [ONEZONE_IA](https://aws.amazon.com/s3/storage-classes/#__) as storage_class
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -90,6 +90,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-restore>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-retry_count>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-retry_delay>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-role_arn>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-role_session_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-rotation_strategy>> |<<string,string>>, one of `["size_and_time", "size", "time"]`|No
@@ -240,6 +242,22 @@ The AWS Region
 
 Used to enable recovery after crash/abnormal termination.
 Temporary log files will be recovered and uploaded.
+
+[id="plugins-{type}s-{plugin}-retry_count"]
+===== `retry_count`
+
+* Value type is <<number,number>>
+* Default value is `Infinity`
+
+Allows to limit number of retries when S3 uploading fails.
+
+[id="plugins-{type}s-{plugin}-retry_delay"]
+===== `retry_delay`
+
+* Value type is <<number,number>>
+* Default value is `1`
+
+Delay (in seconds) to wait between consecutive retries on upload failures.
 
 [id="plugins-{type}s-{plugin}-role_arn"]
 ===== `role_arn`

--- a/lib/logstash/outputs/s3/uploader.rb
+++ b/lib/logstash/outputs/s3/uploader.rb
@@ -48,7 +48,7 @@ module LogStash
             # its either a transient errors or something bad really happened.
             if tries < @retry_count
               tries += 1
-              logger.warn("Uploading failed, retrying (#{tries}).", :exception => e.class, :message => e.message, :path => file.path, :backtrace => e.backtrace)
+              logger.warn("Uploading failed, retrying (##{tries} of #{@retry_count})", :exception => e.class, :message => e.message, :path => file.path, :backtrace => e.backtrace)
               sleep @retry_delay
               retry
             else

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.2.0'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Sends Logstash events to the Amazon Simple Storage Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3/uploader_spec.rb
+++ b/spec/outputs/s3/uploader_spec.rb
@@ -6,7 +6,7 @@ require "aws-sdk"
 require "stud/temporary"
 
 describe LogStash::Outputs::S3::Uploader do
-  let(:logger) { spy(:logger ) }
+  let(:logger) { spy(:logger) }
   let(:max_upload_workers) { 1 }
   let(:bucket_name) { "foobar-bucket" }
   let(:client) { Aws::S3::Client.new(stub_responses: true) }
@@ -14,7 +14,6 @@ describe LogStash::Outputs::S3::Uploader do
   let(:temporary_directory) { Stud::Temporary.pathname }
   let(:temporary_file) { Stud::Temporary.file }
   let(:key) { "foobar" }
-  let(:upload_options) { {} }
   let(:threadpool) do
     Concurrent::ThreadPoolExecutor.new({
                                          :min_threads => 1,
@@ -31,26 +30,40 @@ describe LogStash::Outputs::S3::Uploader do
     f
   end
 
-  subject { described_class.new(bucket, logger, threadpool) }
+  subject { described_class.new(bucket, logger, threadpool, retry_delay: 0.01) }
 
   it "upload file to the s3 bucket" do
     expect { subject.upload(file) }.not_to raise_error
   end
 
   it "execute a callback when the upload is complete" do
-    callback = proc { |f| }
+    callback = proc { |_| }
 
     expect(callback).to receive(:call).with(file)
-    subject.upload(file, { :on_complete => callback })
+    subject.upload(file, :on_complete => callback)
   end
 
-  it "retries errors indefinitively" do
+  it "retries errors indefinitely" do
     s3 = double("s3").as_null_object
 
-    expect(logger).to receive(:error).with(any_args).once
-    expect(bucket).to receive(:object).with(file.key).and_return(s3).twice
-    expect(s3).to receive(:upload_file).with(any_args).and_raise(StandardError)
+    allow(bucket).to receive(:object).with(file.key).and_return(s3)
+
+    expect(logger).to receive(:warn).with(any_args)
+    expect(s3).to receive(:upload_file).with(any_args).and_raise(RuntimeError.new('UPLOAD FAILED')).exactly(5).times
     expect(s3).to receive(:upload_file).with(any_args).and_return(true)
+
+    subject.upload(file)
+  end
+
+  it "retries errors specified times" do
+    subject = described_class.new(bucket, logger, threadpool, retry_count: 3, retry_delay: 0.01)
+    s3 = double("s3").as_null_object
+
+    allow(bucket).to receive(:object).with(file.key).and_return(s3)
+
+    expect(logger).to receive(:warn).with(any_args).exactly(3).times
+    expect(logger).to receive(:error).with(any_args).once
+    expect(s3).to receive(:upload_file).with(file.path, {}).and_raise(RuntimeError).at_least(1).times
 
     subject.upload(file)
   end


### PR DESCRIPTION
initially wanted to filter out specific errors that make sense to get retried (e.g. only rescue-ing `Aws::S3::Errors::ServiceError` and inspecting `error.code`) but possibilities are wild.

resolves https://github.com/logstash-plugins/logstash-output-s3/issues/216 (also closes https://github.com/logstash-plugins/logstash-output-s3/issues/169)