### PR TITLE
Only AWS S3 is supported

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,8 @@ include::{include_path}/plugin_header.asciidoc[]
 
 This plugin batches and uploads logstash events into Amazon Simple Storage Service (Amazon S3).
 
+IMPORTANT: The S3 output plugin only supports AWS S3. Other S3 compatible storage solutions are not supported.
+
 S3 outputs create temporary files into the OS' temporary directory. 
 You can specify where to save them using the `temporary_directory` option.
 


### PR DESCRIPTION
We only support AWS S3, not other S3 compatible storage solutions. This is currently documented in the support matrix (https://www.elastic.co/support/matrix#matrix_logstash_plugins).  It should be documented directly in the plugin guide as well (for the support matrix can be missed).

Please merge to all branches. thx!