### PR TITLE
Doc: Prefix creates temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 4.3.4
+  -  [DOC] Added note about performance implications of interpolated strings in prefixes [#233](https://github.com/logstash-plugins/logstash-output-s3/pull/233)
+
 ## 4.3.3
-  -  [DOC] Update links to use shared attributes [#230](https://github.com/logstash-plugins/logstash-output-s3/pull/230)
+  -  [DOC] Updated links to use shared attributes [#230](https://github.com/logstash-plugins/logstash-output-s3/pull/230)
 
 ## 4.3.2
   -  [DOC] Added note that only AWS S3 is supported. No other S3 compatible storage solutions are supported. [#223](https://github.com/logstash-plugins/logstash-output-s3/pull/223)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -217,13 +217,18 @@ The endpoint should be an HTTP or HTTPS URL, e.g. https://example.com
   * Value type is <<string,string>>
   * Default value is `""`
 
-Specify a prefix to the uploaded filename, this can simulate directories on S3.
+Specify a prefix to the uploaded filename to simulate directories on S3.
 Prefix does not require leading slash.
 This option supports
 {logstash-ref}/event-dependent-configuration.html#sprintf[Logstash
-interpolation]; for example, files can be prefixed with the event date using
+interpolation]. For example, files can be prefixed with the event date using
 `prefix = "%{+YYYY}/%{+MM}/%{+dd}"`.
-Be warned this can create a lot of temporary local files.
+
+IMPORTANT: Take care when you are using interpolated strings in prefixes. This
+has the potential to create large numbers of unique prefixes, causing large
+numbers of in-progress uploads. This scenario may result in performance and
+stability issues, which can be further exacerbated when you use a
+rotation_strategy that delays uploads.
 
 [id="plugins-{type}s-{plugin}-proxy_uri"]
 ===== `proxy_uri` 

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.3.3'
+  s.version         = '4.3.4'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Sends Logstash events to the Amazon Simple Storage Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Add stronger caution that using prefixes can create an abundance of temp files and may impact performance. 
