### PR TITLE
signature_version support s3 not v2

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -103,7 +103,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-server_side_encryption>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-server_side_encryption_algorithm>> |<<string,string>>, one of `["AES256", "aws:kms"]`|No
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-signature_version>> |<<string,string>>, one of `["v2", "v4"]`|No
+| <<plugins-{type}s-{plugin}-signature_version>> |<<string,string>>, one of `["s3", "v4"]`|No
 | <<plugins-{type}s-{plugin}-size_file>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssekms_key_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-storage_class>> |<<string,string>>, one of `["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA"]`|No

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -164,7 +164,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   # The version of the S3 signature hash to use. Normally uses the internal client default, can be explicitly
   # specified here
-  config :signature_version, :validate => ['v2', 'v4']
+  config :signature_version, :validate => ['s3', 'v4']
 
   # Define tags to be appended to the file on the S3 bucket.
   #

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -30,7 +30,7 @@ describe LogStash::Outputs::S3 do
   context "#register configuration validation" do
     describe "signature version" do
       it "should set the signature version if specified" do
-        ["v2", "v4"].each do |version|
+        ["s3", "v4"].each do |version|
           s3 = described_class.new(options.merge({ "signature_version" => version }))
           expect(s3.full_options).to include(:signature_version => version)
         end


### PR DESCRIPTION
- issue
when using logstash output s3 plugin with `signature_version => 'v2'`, error is occurred
    - error message
`
[ERROR][logstash.outputs.s3      ][main] Error validating bucket write permissions! {:message=>"unsupported signature version \"v2\", valid options: 'v4' (default), 's3'", :class=>"RuntimeError", :backtrace=>["/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/aws-sdk-core-2.11.632/lib/aws-sdk-core/plugins/s3_request_signer.rb:20:in ...`

    - environment
        docker: `docker.elastic.co/logstash/logstash-oss:7.13.1`

From aws-sdk, signature_version supports only `v4` and `s3`, no exist `v2`
- https://github.com/aws/aws-sdk-ruby/blob/v2.11.632/aws-sdk-core/lib/aws-sdk-core/plugins/s3_request_signer.rb#L16-L22