### PR TITLE
Feat: cast true/false values for additional_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.5
+  -  Feat: cast true/false values for additional_settings [#241](https://github.com/logstash-plugins/logstash-output-s3/pull/241)
+
 ## 4.3.4
   -  [DOC] Added note about performance implications of interpolated strings in prefixes [#233](https://github.com/logstash-plugins/logstash-output-s3/pull/233)
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -283,16 +283,23 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   def symbolized_settings
-    @symbolized_settings ||= symbolize_keys(@additional_settings)
+    @symbolized_settings ||= symbolize_keys_and_cast_true_false(@additional_settings)
   end
 
-  def symbolize_keys(hash)
-    return hash unless hash.is_a?(Hash)
-    symbolized = {}
-    hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys(value) }
-    symbolized
+  def symbolize_keys_and_cast_true_false(hash)
+    case hash
+    when Hash
+      symbolized = {}
+      hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys_and_cast_true_false(value) }
+      symbolized
+    when 'true'
+      true
+    when 'false'
+      false
+    else
+      hash
+    end
   end
-
 
   def normalize_key(prefix_key)
     prefix_key.gsub(PathValidator.matches_re, PREFIX_KEY_NORMALIZE_CHARACTER)

--- a/logstash-output-s3.gemspec
+++ b/logstash-output-s3.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-s3'
-  s.version         = '4.3.4'
+  s.version         = '4.3.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Sends Logstash events to the Amazon Simple Storage Service"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -160,13 +160,15 @@ describe LogStash::Outputs::S3 do
     end
 
     describe "additional_settings" do
-      context "when enabling force_path_style" do
+      context "supported settings" do
         let(:additional_settings) do
-          { "additional_settings" => { "force_path_style" => true } }
+          { "additional_settings" => { "force_path_style" => 'true', "ssl_verify_peer" => 'false', "region" => 'eu-west-3' } }
         end
 
         it "validates the prefix" do
-          expect(Aws::S3::Bucket).to receive(:new).twice.with(anything, hash_including(:force_path_style => true)).and_call_original
+          expect(Aws::S3::Bucket).to receive(:new).twice.
+              with(anything, hash_including(:force_path_style => true, :ssl_verify_peer => false, :region => 'eu-west-3')).
+              and_call_original
           described_class.new(options.merge(additional_settings)).register
         end
       end

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -162,12 +162,12 @@ describe LogStash::Outputs::S3 do
     describe "additional_settings" do
       context "supported settings" do
         let(:additional_settings) do
-          { "additional_settings" => { "force_path_style" => 'true', "ssl_verify_peer" => 'false', "region" => 'eu-west-3' } }
+          { "additional_settings" => { "force_path_style" => 'true', "ssl_verify_peer" => 'false', "profile" => 'logstash' } }
         end
 
         it "validates the prefix" do
           expect(Aws::S3::Bucket).to receive(:new).twice.
-              with(anything, hash_including(:force_path_style => true, :ssl_verify_peer => false, :region => 'eu-west-3')).
+              with(anything, hash_including(:force_path_style => true, :ssl_verify_peer => false, :profile => 'logstash')).
               and_call_original
           described_class.new(options.merge(additional_settings)).register
         end


### PR DESCRIPTION
This allows us to properly set additional AWS settings e.g.
```ruby
output {
  s3 {
    ...
    additional_settings => {
      force_path_style => true
      ssl_verify_peer => false
    }
  }
}
```

*NOTE: could be extended to cast Float/Integer but for now we're mostly after `ssl_verify_peer => false` ...*