### PR TITLE
Test: work-around issue with JRuby 9.3.4

### DIFF
--- a/spec/outputs/s3/file_repository_spec.rb
+++ b/spec/outputs/s3/file_repository_spec.rb
@@ -88,8 +88,8 @@ describe LogStash::Outputs::S3::FileRepository do
 
   it "returns all available keys" do
     subject.get_file(prefix_key) { |file| file.write("something") }
-    expect(subject.keys.toArray).to include(prefix_key)
-    expect(subject.keys.toArray.size).to eq(1)
+    expect(subject.keys).to include(prefix_key)
+    expect(subject.keys.to_a.size).to eq(1)
   end
 
   it "clean stale factories" do


### PR DESCRIPTION
```
TypeError: illegal access on 'toArray': class
org.jruby.javasupport.JavaMethod (in module org.jruby.dist) cannot
access a member of class
java.util.concurrent.ConcurrentHashMap$CollectionView (in module
java.base) with modifiers "public final"
```
and
```
TypeError: illegal access on 'size': class
org.jruby.javasupport.JavaMethod (in module org.jruby.dist) cannot
access a member of class
java.util.concurrent.ConcurrentHashMap$CollectionView (in module
java.base) with modifiers "public final"
```

upstream bug report: https://github.com/jruby/jruby/issues/7244

:red_circle: CI: https://app.travis-ci.com/github/logstash-plugins/logstash-output-s3/jobs/573433528