### PR TITLE
Crash recovery now respects retry_count and retry_delay

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -395,7 +395,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   # The upload process will use a separate uploader/threadpool with less resource allocated to it.
   # but it will use an unbounded queue for the work, it may take some time before all the older files get processed.
   def restore_from_crash
-    @crash_uploader = Uploader.new(bucket_resource, @logger, CRASH_RECOVERY_THREADPOOL)
+    @crash_uploader = Uploader.new(bucket_resource, @logger, CRASH_RECOVERY_THREADPOOL, retry_count: @retry_count, retry_delay: @retry_delay)
 
     temp_folder_path = Pathname.new(@temporary_directory)
     files = Dir.glob(::File.join(@temporary_directory, "**/*"))


### PR DESCRIPTION
We noticed that during crash recovery the configurable retry settings (count and delay) were not respected. I wasn't sure if there was a reason for this, but if not this PR addresses that behaviour.

Previously while performing crash recovery:

```
[2023-01-31T17:32:53,179][WARN ][logstash.outputs.s3      ] Uploading failed, retrying (#78 of Infinity) {:exception=>Aws::S3::Errors::AccessDenied,...
```

Now:

```
[2023-01-31T17:52:00,265][WARN ][logstash.outputs.s3      ] Uploading failed, retrying (#3 of 50) {:exception=>Aws::S3::Errors::AccessDenied, :message=>"Access Denied",...
```